### PR TITLE
Fix #2 (failure to detect undefined labels)

### DIFF
--- a/assembler.js
+++ b/assembler.js
@@ -2142,7 +2142,7 @@ function SimulatorWidget(node) {
           return true;
         } else {
           pushWord(0x1234);
-          return true;
+          return false;
         }
       }
 
@@ -2174,7 +2174,7 @@ function SimulatorWidget(node) {
           return true;
         } else {
           pushWord(0x1234);
-          return true;
+          return false;
         }
       }
       return false;
@@ -2251,7 +2251,7 @@ function SimulatorWidget(node) {
           return true;
         } else {
           pushWord(0x1234);
-          return true;
+          return false;
         }
       }
       return false;


### PR DESCRIPTION
I already posted about this on the bug report: since no one has responded there I figured I'd open a pull request.

This should prevent undefined labels from being silently ignored and replaced with a jump to 0x1234. All it does is make the assembler return an error when an undefined label is encountered instead of pretending everything was successful.

If I had to guess, I'd say 0x1234 is being pushed so it can be detected later from elsewhere. However, the code to actually do this doesn't seem to ever have been implemented, so this is better than nothing.
