### PR TITLE
allow binary format for immediate addressing mode

### DIFF
--- a/assembler.js
+++ b/assembler.js
@@ -2015,6 +2015,13 @@ function SimulatorWidget(node) {
         pushByte(value);
         return true;
       }
+      if (param.match(/^#\%[0-1]{1,8}$/i)) {
+        pushByte(opcode);
+        value = parseInt(param.replace(/^#\%/, ""), 2);
+        if (value < 0 || value > 255) { return false; }
+        pushByte(value);
+        return true;
+      }
       if (param.match(/^#[0-9]{1,3}$/i)) {
         pushByte(opcode);
         value = parseInt(param.replace(/^#/, ""), 10);


### PR DESCRIPTION
This allows the use of a `%` sign to indicate an immediate value in binary format. So e.g. `LDX #%010101` can be used as an equivalent to `LDX #21` or `LDX #$15`. 

The intent is to make it easier for students to visualize, practice, and learn bitwise operations.